### PR TITLE
fix: wire gallery timing URL params so playlist advances on override

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -920,6 +920,11 @@ const paramMapping = {
 	switchInterval: { key: "modeSwitchInterval", parser: (s) => nullNaN(Math.max(60000, parseInt(s))) }, // Minimum 1 minute
 	showModeInfo: { key: "showModeInfo", parser: isTrue },
 
+	// Gallery screensaver timing
+	shaderDisplayDuration: { key: "shaderDisplayDuration", parser: (s) => nullNaN(parseInt(s)) },
+	fortuneDuration: { key: "fortuneDuration", parser: (s) => nullNaN(parseInt(s)) },
+	screenshotCaptureDuration: { key: "screenshotCaptureDuration", parser: (s) => nullNaN(parseInt(s)) },
+
 	// Multi-monitor fullscreen parameters
 	fullscreenMultiple: { key: "fullscreenMultiple", parser: isTrue },
 	fullscreenUniform: { key: "fullscreenUniform", parser: isTrue },


### PR DESCRIPTION
## Summary
`shaderDisplayDuration`, `fortuneDuration`, and `screenshotCaptureDuration` were declared in `gallery.js` but never mapped in `config.js` `paramMapping`, so URL overrides were silently dropped and the gallery always fell back to the 42s default shuffle.

## Verification
- npm run test: 17 passed, 2 skipped
- Playwright repro: `?shaderDisplayDuration=5000` now observed ~5s transitions with 13 advances across 60s and 0 page errors

## Files changed
- js/config.js (+5 lines)